### PR TITLE
Entry for .markdown p contained twice

### DIFF
--- a/resources/css/justlight.min.css
+++ b/resources/css/justlight.min.css
@@ -15536,7 +15536,7 @@ table#tvTreeBorder td#tv_tree_top div {
 }
 
 [dir] .markdown p {
-  margin: 0 0 0.5em;
+  margin-bottom: 0.5rem;
 }
 
 .markdown table {
@@ -15954,14 +15954,6 @@ caption {
 
 .label {
   font-weight: 600;
-}
-
-.markdown p {
-  white-space: pre-wrap;
-}
-
-[dir] .markdown p {
-  margin-bottom: 0.5rem;
 }
 
 .starredname {


### PR DESCRIPTION
Since there is an intensive discussion in the webtrees forum, I noticed that two entries for .markdown p are contained twice in the css file. Since you have just corrected one yourself and there is a conflict with the Vestamodul ClassicLAF, I have also deleted the other one as a test. Thanks for the great theme.